### PR TITLE
Grayscale effect toggle

### DIFF
--- a/src/components/Underpass/UnderpassMap/index.jsx
+++ b/src/components/Underpass/UnderpassMap/index.jsx
@@ -5,7 +5,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 
 import HOTTheme from '../../HOTTheme';
 import API from '../api';
-import { mapStyle } from './mapStyle';
+import { getMapStyle } from './mapStyle';
 import './styles.css';
 
 export default function UnderpassMap({
@@ -18,6 +18,7 @@ export default function UnderpassMap({
   tagKey,
   tagValue,
   highlightDataQualityIssues = true,
+  isShowGrayscale,
 }) {
   const mapContainer = useRef(null);
   const mapRef = useRef(null);
@@ -31,7 +32,7 @@ export default function UnderpassMap({
     if (mapRef.current) return;
 
     const hottheme = HOTTheme();
-    const theme = {...hottheme, ...propsTheme};
+    const theme = { ...hottheme, ...propsTheme };
 
     theme.map.waysFill = {
       'fill-color': highlightDataQualityIssues
@@ -61,7 +62,7 @@ export default function UnderpassMap({
 
     setTheme(theme);
 
-    let rasterStyle = mapStyle;
+    let rasterStyle = getMapStyle(isShowGrayscale);
     if (theme.map.raster) {
       rasterStyle.layers[0].paint = theme.map.raster;
     }
@@ -92,14 +93,14 @@ export default function UnderpassMap({
               type: 'fill',
               source: 'ways',
               layout: {},
-              paint: theme.map.waysFill
+              paint: theme.map.waysFill,
             });
             map.addLayer({
               id: 'waysLine',
               type: 'line',
               source: 'ways',
               layout: {},
-              paint: theme.map.waysLine
+              paint: theme.map.waysLine,
             });
           }
         },
@@ -140,7 +141,6 @@ export default function UnderpassMap({
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [map]);
-
 
   return (
     <div className={mapClassName || 'underpassMap-wrap'}>

--- a/src/components/Underpass/UnderpassMap/index.jsx
+++ b/src/components/Underpass/UnderpassMap/index.jsx
@@ -18,7 +18,7 @@ export default function UnderpassMap({
   tagKey,
   tagValue,
   highlightDataQualityIssues = true,
-  isShowGrayscale,
+  grayscale,
 }) {
   const mapContainer = useRef(null);
   const mapRef = useRef(null);
@@ -62,7 +62,7 @@ export default function UnderpassMap({
 
     setTheme(theme);
 
-    let rasterStyle = getMapStyle(isShowGrayscale);
+    let rasterStyle = getMapStyle(grayscale);
     if (theme.map.raster) {
       rasterStyle.layers[0].paint = theme.map.raster;
     }

--- a/src/components/Underpass/UnderpassMap/mapStyle.js
+++ b/src/components/Underpass/UnderpassMap/mapStyle.js
@@ -1,24 +1,30 @@
-export const mapStyle = {
-  version: 8,
-  sources: {
-    osm: {
-      type: 'raster',
-      tiles: ['https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'],
-      tileSize: 256,
-      attribution: '&copy; OpenStreetMap Contributors',
-      maxzoom: 19,
+export const getMapStyle = (isShowGrayscale) => {
+  return {
+    version: 8,
+    sources: {
+      osm: {
+        type: 'raster',
+        tiles: ['https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'],
+        tileSize: 256,
+        attribution: '&copy; OpenStreetMap Contributors',
+        maxzoom: 19,
+      },
     },
-  },
-  layers: [
-    {
-      id: 'osm',
-      type: 'raster',
-      source: 'osm',
-      paint:  {
-        'raster-opacity': 0.72,
-        'raster-brightness-max': 1,
-        'raster-saturation': -1,
-      }
-    },
-  ],
+    layers: [
+      {
+        id: 'osm',
+        type: 'raster',
+        source: 'osm',
+        ...(isShowGrayscale
+          ? {
+              paint: {
+                'raster-opacity': 0.72,
+                'raster-brightness-max': 1,
+                'raster-saturation': -1,
+              },
+            }
+          : {}),
+      },
+    ],
+  };
 };

--- a/src/components/Underpass/UnderpassMap/mapStyle.js
+++ b/src/components/Underpass/UnderpassMap/mapStyle.js
@@ -1,4 +1,4 @@
-export const getMapStyle = (isShowGrayscale) => {
+export const getMapStyle = (grayscale) => {
   return {
     version: 8,
     sources: {
@@ -15,7 +15,7 @@ export const getMapStyle = (isShowGrayscale) => {
         id: 'osm',
         type: 'raster',
         source: 'osm',
-        ...(isShowGrayscale
+        ...(grayscale
           ? {
               paint: {
                 'raster-opacity': 0.72,

--- a/src/components/Underpass/UnderpassMapNodes/index.jsx
+++ b/src/components/Underpass/UnderpassMapNodes/index.jsx
@@ -5,7 +5,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 
 import HOTTheme from '../../HOTTheme';
 import API from '../api';
-import { mapStyle } from './mapStyle';
+import { getMapStyle } from './mapStyle';
 import './styles.css';
 
 export default function UnderpassMapNodes({
@@ -16,7 +16,8 @@ export default function UnderpassMapNodes({
   minZoom = 13,
   mapClassName,
   tagKey,
-  tagValue
+  tagValue,
+  isShowGrayscale = true,
 }) {
   const mapContainer = useRef(null);
   const mapRef = useRef(null);
@@ -30,7 +31,7 @@ export default function UnderpassMapNodes({
     if (mapRef.current) return;
 
     const hottheme = HOTTheme();
-    const theme = {...hottheme, ...propsTheme};
+    const theme = { ...hottheme, ...propsTheme };
 
     theme.map.nodesFill = {
       'fill-color': `rgb(${theme.colors.primary})`,
@@ -44,7 +45,7 @@ export default function UnderpassMapNodes({
 
     setTheme(theme);
 
-    let rasterStyle = mapStyle;
+    let rasterStyle = getMapStyle(isShowGrayscale);
     if (theme.map.raster) {
       rasterStyle.layers[0].paint = theme.map.raster;
     }
@@ -76,7 +77,7 @@ export default function UnderpassMapNodes({
               source: 'nodes',
               layout: {
                 'icon-image': 'custom-marker',
-              }
+              },
             });
           }
         },
@@ -89,7 +90,8 @@ export default function UnderpassMapNodes({
     map.on('load', () => {
       fetchNodes(); // Run immediately on the first time
       isRealTime && setInterval(fetchNodes, 5000);
-      map.loadImage(theme.map.nodesSymbol || '/images/blue-circle.png',
+      map.loadImage(
+        theme.map.nodesSymbol || '/images/blue-circle.png',
         (error, image) => {
           map.addImage('custom-marker', image);
         }
@@ -117,7 +119,6 @@ export default function UnderpassMapNodes({
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [map]);
-
 
   return (
     <div className={mapClassName || 'underpassMap-wrap'}>

--- a/src/components/Underpass/UnderpassMapNodes/index.jsx
+++ b/src/components/Underpass/UnderpassMapNodes/index.jsx
@@ -17,7 +17,7 @@ export default function UnderpassMapNodes({
   mapClassName,
   tagKey,
   tagValue,
-  isShowGrayscale = true,
+  grayscale = true,
 }) {
   const mapContainer = useRef(null);
   const mapRef = useRef(null);
@@ -45,7 +45,7 @@ export default function UnderpassMapNodes({
 
     setTheme(theme);
 
-    let rasterStyle = getMapStyle(isShowGrayscale);
+    let rasterStyle = getMapStyle(grayscale);
     if (theme.map.raster) {
       rasterStyle.layers[0].paint = theme.map.raster;
     }

--- a/src/components/Underpass/UnderpassMapNodes/mapStyle.js
+++ b/src/components/Underpass/UnderpassMapNodes/mapStyle.js
@@ -1,24 +1,30 @@
-export const mapStyle = {
-  version: 8,
-  sources: {
-    osm: {
-      type: 'raster',
-      tiles: ['https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'],
-      tileSize: 256,
-      attribution: '&copy; OpenStreetMap Contributors',
-      maxzoom: 19,
+export const getMapStyle = (isShowGrayscale) => {
+  return {
+    version: 8,
+    sources: {
+      osm: {
+        type: 'raster',
+        tiles: ['https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'],
+        tileSize: 256,
+        attribution: '&copy; OpenStreetMap Contributors',
+        maxzoom: 19,
+      },
     },
-  },
-  layers: [
-    {
-      id: 'osm',
-      type: 'raster',
-      source: 'osm',
-      paint:  {
-        'raster-opacity': 0.72,
-        'raster-brightness-max': 1,
-        'raster-saturation': -1,
-      }
-    },
-  ],
+    layers: [
+      {
+        id: 'osm',
+        type: 'raster',
+        source: 'osm',
+        ...(isShowGrayscale
+          ? {
+              paint: {
+                'raster-opacity': 0.72,
+                'raster-brightness-max': 1,
+                'raster-saturation': -1,
+              },
+            }
+          : {}),
+      },
+    ],
+  };
 };

--- a/src/components/Underpass/UnderpassMapNodes/mapStyle.js
+++ b/src/components/Underpass/UnderpassMapNodes/mapStyle.js
@@ -1,4 +1,4 @@
-export const getMapStyle = (isShowGrayscale) => {
+export const getMapStyle = (grayscale) => {
   return {
     version: 8,
     sources: {
@@ -15,7 +15,7 @@ export const getMapStyle = (isShowGrayscale) => {
         id: 'osm',
         type: 'raster',
         source: 'osm',
-        ...(isShowGrayscale
+        ...(grayscale
           ? {
               paint: {
                 'raster-opacity': 0.72,

--- a/src/fixtures/UnderpassMap.fixture.jsx
+++ b/src/fixtures/UnderpassMap.fixture.jsx
@@ -28,11 +28,14 @@ const theme = {
   // }
 };
 
-export default <UnderpassMap 
-  mapClassName={"customMap"}
-  center={center}
-  theme={theme}
-  tagKey="building"
-  tagValue="yes"
-  highlightDataQualityIssues
-/>;
+export default (
+  <UnderpassMap
+    mapClassName={'customMap'}
+    center={center}
+    theme={theme}
+    tagKey='building'
+    tagValue='yes'
+    highlightDataQualityIssues
+    isShowGrayscale={true}
+  />
+);

--- a/src/fixtures/UnderpassMap.fixture.jsx
+++ b/src/fixtures/UnderpassMap.fixture.jsx
@@ -36,6 +36,6 @@ export default (
     tagKey='building'
     tagValue='yes'
     highlightDataQualityIssues
-    isShowGrayscale={true}
+    grayscale={true}
   />
 );

--- a/src/fixtures/UnderpassMapNodes.fixture.jsx
+++ b/src/fixtures/UnderpassMapNodes.fixture.jsx
@@ -7,6 +7,6 @@ export default (
     center={center}
     tagKey='amenity'
     tagValue=''
-    isShowGrayscale
+    grayscale
   />
 );

--- a/src/fixtures/UnderpassMapNodes.fixture.jsx
+++ b/src/fixtures/UnderpassMapNodes.fixture.jsx
@@ -2,8 +2,11 @@ import React from 'react';
 import UnderpassMapNodes from '../components/Underpass/UnderpassMapNodes';
 import { center } from './center';
 
-export default <UnderpassMapNodes 
-  center={center}
-  tagKey="amenity"
-  tagValue=""
-/>;
+export default (
+  <UnderpassMapNodes
+    center={center}
+    tagKey='amenity'
+    tagValue=''
+    isShowGrayscale
+  />
+);


### PR DESCRIPTION
- Replaced `mapStyle` with a function, `getMapStyle`, which now accepts an `grayscale` argument.
- Updated the `UnderpassMap` and `UnderpassMapNodes` components to accept the new `isShowGrayscale` prop.
- Integrated the `grayscale` prop into the `getMapStyle` function to apply or exclude the grayscale filter based on the prop provided.
