### PR TITLE
Enhance popup UI for tag display

### DIFF
--- a/cosmos.config.json
+++ b/cosmos.config.json
@@ -1,3 +1,4 @@
 {
-    "staticPath": "public"
+  "globalImports": ["src/index.css"],
+  "staticPath": "public"
 }

--- a/src/components/Underpass/UnderpassMap/index.jsx
+++ b/src/components/Underpass/UnderpassMap/index.jsx
@@ -151,6 +151,15 @@ export default function UnderpassMap({
 
 const Popup = ({ feature, highlightDataQualityIssues }) => {
   const tags = JSON.parse(feature.properties.tags);
+  const [showAll, setShowAll] = useState(false);
+
+  const toggleShowAll = () => {
+    setShowAll(!showAll);
+  };
+
+  const visibleTags = showAll
+    ? Object.keys(tags)
+    : Object.keys(tags).slice(0, 2);
 
   return (
     <div className='popup'>
@@ -167,10 +176,10 @@ const Popup = ({ feature, highlightDataQualityIssues }) => {
               </a>
             </td>
           </tr>
-          {Object.keys(tags).map((tag) => (
+          {visibleTags.map((tag) => (
             <tr key={tag}>
-              <td>{tag}</td>
-              <td>{tags[tag]}</td>
+              <td width='60%'>{tag}</td>
+              <td width='40%'>{tags[tag]}</td>
             </tr>
           ))}
           {highlightDataQualityIssues && feature.properties.status && (
@@ -182,6 +191,18 @@ const Popup = ({ feature, highlightDataQualityIssues }) => {
           )}
         </tbody>
       </table>
+      {!showAll && Object.keys(tags).length > 2 && (
+        <button className='more-btn' onClick={toggleShowAll}>
+          More ...
+        </button>
+      )}
+      {feature.properties.status && (
+        <div
+          className={`status status-bg-${feature.properties.status.toLowerCase()}`}
+        >
+          {feature.properties.status}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Underpass/UnderpassMap/styles.css
+++ b/src/components/Underpass/UnderpassMap/styles.css
@@ -64,14 +64,19 @@ from https://github.com/mapbox/mapbox-gl-js/issues/8368#issuecomment-537597959*/
 table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
+  margin-bottom: 0.5rem;
 }
 
-tr:not(:last-child) {
+tr {
   border-bottom: 1px solid var(--hottheme-color-divider);
 }
 
 td {
   padding: 0.5rem 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 a {
@@ -84,7 +89,28 @@ a:hover {
   text-decoration: underline;
 }
 
+.more-btn {
+  display: block;
+  padding: 0;
+  border: 0;
+  background-color: transparent;
+  text-decoration: underline;
+}
+
+.more-btn:hover {
+  cursor: pointer;
+}
+
 .status {
-  color: rgb(var(--hottheme-color-primary));
+  display: inline-block;
+  color: #fff;
   text-transform: capitalize;
+  margin-top: 0.75rem;
+  border-radius: 0.125rem;
+  font-weight: bold;
+  padding: 0.25rem 0.5rem;
+}
+
+.status-bg-badgeom {
+  background-color: rgb(var(--hottheme-color-primary));
 }

--- a/src/components/Underpass/UnderpassMapNodes/styles.css
+++ b/src/components/Underpass/UnderpassMapNodes/styles.css
@@ -85,6 +85,11 @@ a:hover {
 }
 
 .status {
-  color: rgb(var(--hottheme-color-primary));
+  display: inline-block;
+  color: #fff;
   text-transform: capitalize;
+  margin-top: 0.75rem;
+  border-radius: 0.125rem;
+  font-weight: bold;
+  padding: 0.25rem 0.5rem;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  color: var(--hottheme-color-text-primary);
 }
 
 code {


### PR DESCRIPTION
- Initially showcases a limited set of two tags and incorporates a "More ..." button, allowing users to reveal the complete tag list.
- The width of the tag cells has been adjusted to the ratio of 3:2, and an ellipsis will denote any overflowing text within cells.
- The status of a feature, if available, is now displayed with an appropriately styled status div


![popup](https://github.com/hotosm/underpass-ui/assets/51614993/29b9ff8f-e54e-4909-bc8e-011261ffc0a6)

**To-Dos:**
- [ ]  Accommodate multiple validation statuses
- [ ] Implement a flexible color scheme for elements within the popup UI